### PR TITLE
Fix error

### DIFF
--- a/prose-doc.cabal
+++ b/prose-doc.cabal
@@ -33,7 +33,7 @@ library
     , split              >= 0.2
     , blaze-markup       >= 0.6
     , blaze-html         >= 0.7
-    , pandoc             >= 1.12
+    , pandoc             >= 1.13
     , haskell-src-exts   >= 1.15
     , syb                >= 0.3
     , filepath           >= 1.3

--- a/src/Text/ProseDoc.hs
+++ b/src/Text/ProseDoc.hs
@@ -19,8 +19,9 @@ import Control.Applicative ((<$>))
 import Control.Monad       ((<=<), filterM, forM)
 import Control.Error
 
-import Data.Monoid (mempty)
-import Data.List   (sort, isPrefixOf)
+import Data.Default (def)
+import Data.Monoid  (mempty)
+import Data.List    (sort, isPrefixOf)
 
 import System.Directory (getDirectoryContents, doesFileExist, doesDirectoryExist)
 import System.FilePath  ((</>), takeExtension, makeRelative)
@@ -52,7 +53,7 @@ is used to embed the style information from an external css file.
 -}
     cssPath <- getDataFileName "css/prose.css"
 
-    makeSelfContained Nothing
+    makeSelfContained def
         $ renderPage cssPath mempty
         $ [moduleToHtml (path, t)]
 
@@ -86,6 +87,6 @@ first.
     let toc = htmlTOC mods
     cssPath <- getDataFileName "css/prose.css"
 
-    makeSelfContained Nothing $ renderPage cssPath toc htmls
+    makeSelfContained def $ renderPage cssPath toc htmls
 
 


### PR DESCRIPTION
The Pandoc interface changed. Instead of `Nothing` now `def` (from
Data.Default) seems appropriate.

Should solve #1. I don't know if `def` is actually OK, so I'd love to get any code review.
